### PR TITLE
Fixing Tx URLs in CFG and SAIL balance function

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -35,8 +35,8 @@ export const GUILD_ID='847485334157656107'
 export const LOG_CHANNEL_ID='847485334157656113'
 
 export const TRANSACTION_EXPLORERS = {
-  SOLSCAN:  'https://solscan.io/tx/%s',
-  SOLANA:   'https://explorer.solana.com/tx/%s' + ACTIVE_CLUSTER !== CLUSTERS.MAINNET ? `?cluster=${ACTIVE_CLUSTER}` : '',
+  SOLSCAN:  'https://solscan.io/tx/%s' + (( ACTIVE_CLUSTER !== CLUSTERS.MAINNET ) ? `?cluster=${ACTIVE_CLUSTER}` : ''),
+  SOLANA:   'https://explorer.solana.com/tx/%s' + (( ACTIVE_CLUSTER !== CLUSTERS.MAINNET ) ? `?cluster=${ACTIVE_CLUSTER}` : ''),
 };
 
 export const EXPECTED_ROLES=[

--- a/src/solana/index.js
+++ b/src/solana/index.js
@@ -146,7 +146,7 @@ const getSAILBalance = async (privateKey) => {
 
   return {
     isExistToken: true,
-    amount: account.amount / 1000000
+    amount: account.amount / 1000000000
   };
 }
 


### PR DESCRIPTION
- Fixed some error in forming the URLs to solscan or solexplorer.
- Fixed wrong SAIL balance calculation (getSAILBalance function): shifted 3 zeros.
- Added one issue about showing wrongly zero balances when Solana or RPC are down/busy, and tipbot not reporting anything.