### PR TITLE
Upgrading error handling in Rain command

### DIFF
--- a/index.js
+++ b/index.js
@@ -758,7 +758,7 @@ client.on('messageCreate', async (message) => {
         try {
            await fetchedUser.send({
             embeds: [new MessageEmbed()
-              .setColor(errorColor)
+              .setColor(dangerColor)
               .setTitle(`Rain ${label} Error`)
               .setDescription(error)
             ]

--- a/index.js
+++ b/index.js
@@ -743,8 +743,6 @@ client.on('messageCreate', async (message) => {
         return;
       }
 
-      boardInfo.users.push(user)
-
       const transfer = ( label == 'SAIL')  ? solanaConnect.transferSAIL  :
                        ( label == 'gSAIL') ? solanaConnect.transferGSAIL :
                        ( label == 'SOL')   ? solanaConnect.transferSOL   : null, // in case rainsol is ever added ;D
@@ -752,15 +750,31 @@ client.on('messageCreate', async (message) => {
                                                        await Wallet.getPublicKey(user.id),
                                                        amount / maxPeople, `Rain ${label}` )
 
+      let fetchedUser = await client.users.fetch(user.id, false);
+      
       if( !success ) {
         console.log(`Error while raining ${label}`, error)
+
+        try {
+           await fetchedUser.send({
+            embeds: [new MessageEmbed()
+              .setColor(errorColor)
+              .setTitle(`Rain ${label} Error`)
+              .setDescription(error)
+            ]
+          });
+        } catch (error) {
+          console.log(`Cannot send messages to this user`);
+        }        
+        
         return;
       }
 
+      boardInfo.users.push(user)
+      
       const msg = `You received ${amount / maxPeople} ${label}\nTransaction: ${ solanaConnect.txLink(signature) }`
       try {
         // DM to recipient
-        let fetchedUser = await client.users.fetch(user.id, false);
         await fetchedUser.send({
           embeds: [new MessageEmbed()
             .setColor(infoColor)


### PR DESCRIPTION
* Sending a message to the user that reacts to the rain, when a rain error occurs: We will notify errors to the "applicants".
* Changing the order of pushing the user to the list of "Rain receivers": Now will added only if transaction succeed. If the transaction does not occur then the user will not be added to the list and can react again.